### PR TITLE
Travis update - rspec flack dependency and bundler caching

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---exclude-pattern "spec/dummy/flor/spec/**/*_spec.rb,spec/dummy/flor/spec/*,spec/dummy/flack/spec/**/*_spec.rb" -fd
+--exclude-pattern "spec/dummy/flor/spec/**/*_spec.rb,spec/dummy/flor/spec/*,spec/dummy/flack/spec/**/*_spec.rb,spec/dummy/rails_app/vendor/**/*" -fd

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ rvm:
  - 2.1
 
 before_script:
-  - git clone https://github.com/floraison/flack ../flack
-  - cd ../flack
-  - bundle install
-  - make migrate
-  - make start
+  - bundle exec rake app:server:flack:install
+  - bundle exec rake app:server:flack:start
 
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: ruby
+cache: bundler
 rvm:
  - 2.1
+
+before_script:
+  - git clone https://github.com/floraison/flack ../flack
+  - cd ../flack
+  - bundle install
+  - make migrate
+  - make start
+
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
  - 2.1
 
 before_script:
+  - bundle exec rake app:server:rails:install_dep
   - bundle exec rake app:server:flack:install
   - bundle exec rake app:server:flack:start
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 
 before_script:
   - bundle exec rake app:server:rails:install_dep
+  - bundle exec rake app:server:rails:assets_precompile
   - bundle exec rake app:server:flack:install
   - bundle exec rake app:server:flack:start
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
-cache: bundler
+cache: 
+  - bundler: true
+  - directories:
+    - /home/travis/.rvm/
 rvm:
  - 2.1
 

--- a/app/assets/javascripts/floristry/application.js
+++ b/app/assets/javascripts/floristry/application.js
@@ -1,0 +1,15 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require jquery
+//= require jquery_ujs
+//= require_tree .

--- a/app/assets/stylesheets/floristry/application.scss
+++ b/app/assets/stylesheets/floristry/application.scss
@@ -1,0 +1,13 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the top of the
+ * compiled file, but it's generally better to create a new file per style scope.
+ *
+ *= require_self
+ *= require_tree .
+ */

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -28,25 +28,49 @@ namespace :server do
   end
 
   namespace :flack do
-    desc "Start Flack: Rack app for the flor workflow engine"
+    flack_path = "../flack"
+
+    desc "Start Flack: Rack app for the Flor workflow engine"
     task :start do
-       chdir "../flack" do
+       chdir flack_path do
          sh %{ make start }
        end
     end
 
     desc "Stop Flack"
     task :stop do
-      chdir "../flack" do
+      chdir flack_path do
         sh %{ make stop }
       end
     end
 
     desc "Restart Flack"
     task :restart do
-      chdir "../flack" do
+      chdir flack_path do
         sh %{ make restart }
       end
     end
-  end
+
+    desc "Clone Flack"
+    task :clone do
+      sh %{ git clone https://github.com/floraison/flack ../flack }
+    end
+
+    desc "Install Flack's dependencies"
+    task :install_dep do
+      chdir flack_path do
+        sh %{ bundle install }
+      end
+    end
+
+    desc "Run Flack's migration"
+    task :migrate do
+      chdir flack_path do
+        sh %{ make migrate }
+      end
+    end
+
+    desc "Install Flack"
+      task :install => %w[flack:clone flack:install_dep flack:migrate]
+    end
 end

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -58,9 +58,7 @@ namespace :server do
 
     desc "Install Flack's dependencies"
     task :install_dep do
-      chdir flack_path do
-        sh %{ bundle install }
-      end
+      sh %{ bundle install --gemfile=#{flack_path}/Gemfile }
     end
 
     desc "Run Flack's migration"

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -10,6 +10,15 @@ namespace :server do
   task :restart => [:'flack:restart', :'rails:restart']
 
   namespace :rails do
+    desc "Precompile assets"
+    task :assets_precompile do
+      chdir "spec/dummy/rails_app" do
+        Bundler.with_clean_env do
+          sh "RAILS_ENV=test bundle exec rake assets:precompile"
+        end
+      end
+    end
+
     desc "Start rails"
     task :start do
       sh %{bundle exec rails s -d}

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -25,6 +25,17 @@ namespace :server do
       Rake::Task["server:rails:stop"].invoke
       Rake::Task["server:rails:start"].invoke
     end
+
+    desc "Install rails deps"
+    task :install_dep do
+      chdir "spec/dummy/rails_app" do
+        Bundler.with_clean_env do
+          sh "bundle install"
+        end
+      end
+    end
+
+
   end
 
   namespace :flack do


### PR DESCRIPTION
- Caching bundler dependencies reduces build time
- Having a running flack instance is required by some specs