### PR TITLE
From clone to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,24 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=e6f123c837b138a2d1408891c4355c8013568887ae04be75f5912e049600ad24
+services:
+  - docker
 language: ruby
-cache: 
+cache:
   - bundler: true
   - directories:
-    - /home/travis/.rvm/
+      - /home/travis/.rvm/
 rvm:
- - 2.1
+  - 2.1
+before_install:
+  - docker build -t flack .
+  - docker run -d flack:latest /bin/sh -c "cd flack/ ; make serve"
+  - CONTAINER=`docker ps -aql`
+  - CONTAINER_IP=`docker inspect $CONTAINER | grep '"IPAddress"' | head -n 1 | grep -oE "([0-9]{1,3}\.){3}[0-9]{1,3}"`
+  - sed -i "s/localhost/$CONTAINER_IP/g" lib/floristry/workflow_engine.rb
 
 before_script:
-  - bundle exec rake app:server:rails:install_dep
-  - bundle exec rake app:server:rails:assets_precompile
-  - bundle exec rake app:server:flack:install
-  - bundle exec rake app:server:flack:start
+  - bundle exec rake app:floristry:setup_dummy
 #  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 #  - chmod +x ./cc-test-reporter
 #  - ./cc-test-reporter before-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Used to run Flack in a container
+FROM ruby:2.3.8-jessie
+
+EXPOSE 7007:7007
+
+RUN apt-get update && apt-get install git
+RUN git clone https://github.com/floraison/flack
+RUN sed -i 's/bundle exec rackup -p $(PORT)/bundle exec rackup -p $(PORT) --host 0.0.0.0/g' flack/Makefile
+RUN cd flack && bundle install && make migrate

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ TODO
 
 4. TODO
 
+## Testing
+
+1. Clone the gem
+2. Run `rake app:floristry:setup_dummy` form the gem's root directory. This will install [Flack](https://github.com/floraison/flack)
+3. Start Flack and the dummy rails app `rake app:server:start`
+4. Run the specs `bundle exec rspec` (specs need a running flack instance).
+5. Use the dummy app listening at localhost:3000 for testing.
+6. Stop all the servers: `rake app:server:stop`
+
 ## Usage
 TODO
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ TODO
 ## Testing
 
 1. Clone the gem
-2. Run `rake app:floristry:setup_dummy` form the gem's root directory. This will install [Flack](https://github.com/floraison/flack)
-3. Start Flack and the dummy rails app `rake app:server:start`
-4. Run the specs `bundle exec rspec` (specs need a running flack instance).
-5. Use the dummy app listening at localhost:3000 for testing.
-6. Stop all the servers: `rake app:server:stop`
+2. Run `bundle install`
+3. Run `rake app:floristry:setup_flack` This will install [Flack](https://github.com/floraison/flack)
+3. Run `rake app:floristry:setup_dummy` from the gem's root directory.
+4. Start Flack and the dummy rails app `rake app:server:start`
+5. Run the specs `bundle exec rspec` (specs need a running flack instance).
+6. Use the dummy app listening at localhost:3000 for testing.
+7. Stop all the servers: `rake app:server:stop`
 
 ## Usage
 TODO

--- a/lib/generators/floristry/install_generator.rb
+++ b/lib/generators/floristry/install_generator.rb
@@ -3,6 +3,7 @@ require 'rails/generators/base'
 module Floristry
   class InstallGenerator < Rails::Generators::Base
     class_option :flack_and_flor, :type => :boolean, :default => false, :desc => "Install Flack and Flor"
+    class_option :flack_dir, :type => :string, :default => '../flack', :desc => "Flack installation dir"
 
     source_root File.expand_path('../templates', __FILE__)
 
@@ -56,11 +57,14 @@ module Floristry
             run('make migrate')
           end
         end
-
-        say("Copying default Flack hooks and taskers inside ../flack/envs/dev/lib/")
-        directory("flack/lib/hooks/", "../flack/envs/dev/lib/hooks")
-        directory("flack/lib/taskers/", "../flack/envs/dev/lib/taskers")
       end
+    end
+
+    def  pollen_hooks_and_taskers
+
+      say("Copying default Flack hooks and taskers inside #{options[:flack_dir]}")
+      directory("flack/lib/hooks/", "#{options[:flack_dir]}envs/dev/lib/hooks")
+      directory("flack/lib/taskers/", "#{options[:flack_dir]}/flack/envs/dev/lib/taskers")
     end
   end
 end

--- a/lib/generators/floristry/migrate_generator.rb
+++ b/lib/generators/floristry/migrate_generator.rb
@@ -13,7 +13,7 @@ module Floristry
 
     def migrate
 
-      rake("db:migrate SCOPE=floristry")
+      rake("db:migrate")
     end
 
     def self.next_migration_number path

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -110,9 +110,13 @@ end
 
 namespace :floristry do
 
-  desc "Install Floristry and all dependencies for testing with dummy app"
-  task :setup_dummy do
+  desc "Install Flack locally"
+  task :setup_flack do
     Rake::Task["app:server:flack:install"].invoke
+  end
+
+  desc "Install Floristry for testing with dummy app"
+  task :setup_dummy do
 
     Bundler.with_clean_env do
       Rake::Task["app:server:rails:install_dep"].invoke

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -1,4 +1,6 @@
 namespace :server do
+  # Default, todo make this configurable.
+  flack_path = Gem::Specification.find_by_name("floristry").gem_dir + '/../flack'
 
   desc "Start all servers"
   task :start => [:'flack:start', :'rails:start']
@@ -41,12 +43,12 @@ namespace :server do
         Bundler.with_clean_env do
           sh "bundle install"
         end
+        sh "rails g floristry:install --flack-dir=#{flack_path}"
       end
     end
   end
 
   namespace :flack do
-    flack_path = Gem::Specification.find_by_name("floristry").gem_dir + '/../flack'
 
     desc "Start Flack: Rack app for the Flor workflow engine"
     task :start do

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -110,15 +110,13 @@ end
 
 namespace :floristry do
 
-  desc "Install Floristry and all dependencies"
-  task :setup do
+  desc "Install Floristry and all dependencies for testing with dummy app"
+  task :setup_dummy do
     Rake::Task["app:server:flack:install"].invoke
 
-    chdir "spec/dummy/rails_app" do
-      Bundler.with_clean_env do
-        sh "bundle install"
-        sh "RAILS_ENV=test bundle exec rake assets:precompile"
-      end
+    Bundler.with_clean_env do
+      Rake::Task["app:server:rails:install_dep"].invoke
+      Rake::Task["app:server:rails:precompile_and_migrate"].invoke
     end
   end
 end

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -12,11 +12,12 @@ namespace :server do
   task :restart => [:'flack:restart', :'rails:restart']
 
   namespace :rails do
-    desc "Precompile assets"
-    task :assets_precompile do
+    desc "Precompile assets and migrate db"
+    task :precompile_and_migrate do
       chdir "spec/dummy/rails_app" do
         Bundler.with_clean_env do
           sh "RAILS_ENV=test bundle exec rake assets:precompile"
+          sh "RAILS_ENV=test bundle exec rake db:migrate"
         end
       end
     end

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -24,12 +24,18 @@ namespace :server do
 
     desc "Start rails"
     task :start do
-      sh %{bundle exec rails s -d}
+      chdir "spec/dummy/rails_app" do
+        Bundler.with_clean_env do
+          sh %{bundle exec rails s -d}
+        end
+      end
     end
 
     desc "Stop rails"
     task :stop do
-      sh %{if [ -f tmp/pids/server.pid ]; then kill `cat tmp/pids/server.pid`; fi}
+      chdir "spec/dummy/rails_app" do
+        sh %{if [ -f tmp/pids/server.pid ]; then kill `cat tmp/pids/server.pid`; fi}
+      end
     end
 
     desc "Restart rails"

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -46,26 +46,32 @@ namespace :server do
   end
 
   namespace :flack do
-    flack_path = "../flack"
+    flack_path = Gem::Specification.find_by_name("floristry").gem_dir + '/../flack'
 
     desc "Start Flack: Rack app for the Flor workflow engine"
     task :start do
-      chdir flack_path do
-        sh %{ make start }
+      Bundler.with_clean_env do
+        chdir flack_path do
+          sh %{ make start }
+        end
       end
     end
 
     desc "Stop Flack"
     task :stop do
-      chdir flack_path do
-        sh %{ make stop }
+      Bundler.with_clean_env do
+        chdir flack_path do
+          sh %{ make stop }
+        end
       end
     end
 
     desc "Restart Flack"
     task :restart do
-      chdir flack_path do
-        sh %{ make restart }
+      Bundler.with_clean_env do
+        chdir flack_path do
+          sh %{ make restart }
+        end
       end
     end
 

--- a/spec/dummy/rails_app/lib/tasks/server.rake
+++ b/spec/dummy/rails_app/lib/tasks/server.rake
@@ -43,8 +43,6 @@ namespace :server do
         end
       end
     end
-
-
   end
 
   namespace :flack do
@@ -52,9 +50,9 @@ namespace :server do
 
     desc "Start Flack: Rack app for the Flor workflow engine"
     task :start do
-       chdir flack_path do
-         sh %{ make start }
-       end
+      chdir flack_path do
+        sh %{ make start }
+      end
     end
 
     desc "Stop Flack"
@@ -73,7 +71,7 @@ namespace :server do
 
     desc "Clone Flack"
     task :clone do
-      sh %{ git clone https://github.com/floraison/flack ../flack }
+      sh %{ git clone https://github.com/floraison/flack #{flack_path} }
     end
 
     desc "Install Flack's dependencies"
@@ -83,12 +81,29 @@ namespace :server do
 
     desc "Run Flack's migration"
     task :migrate do
-      chdir flack_path do
-        sh %{ make migrate }
+      Bundler.with_clean_env do
+        chdir flack_path do
+          sh %{ make migrate }
+        end
       end
     end
 
     desc "Install Flack"
-      task :install => %w[flack:clone flack:install_dep flack:migrate]
+    task :install => %w[flack:clone flack:install_dep flack:migrate]
+  end
+end
+
+namespace :floristry do
+
+  desc "Install Floristry and all dependencies"
+  task :setup do
+    Rake::Task["app:server:flack:install"].invoke
+
+    chdir "spec/dummy/rails_app" do
+      Bundler.with_clean_env do
+        sh "bundle install"
+        sh "RAILS_ENV=test bundle exec rake assets:precompile"
+      end
     end
+  end
 end


### PR DESCRIPTION
Refactor rake tasks and install generator used to setup.

Changes `.travis.yml` to use a container ( docker ) to run flack. This was primarily motivated by the bundler issues we had on Travis, where we had errors related to missing gems. 
For example, we'd install our dependencies, move to another directory, clone flack, install his dependencies using bundler, and then we'd run `make migrate`, which would fail on missing dependencies.

Running flack this way also reinforces the idea that flor is a completely decoupled system with which we interact over HTTP.

For our specs, flack remains installed and ran locally, for simplicity's sake. 

Adds the steps to go from clone to test ( rspec ) in README.md. 

Closes #38 